### PR TITLE
修复ts路径问题

### DIFF
--- a/m3u8manger_lib/src/main/java/com/hdl/m3u8/M3U8DownloadTask.java
+++ b/m3u8manger_lib/src/main/java/com/hdl/m3u8/M3U8DownloadTask.java
@@ -274,12 +274,7 @@ public class M3U8DownloadTask {
                         FileOutputStream fos = null;
                         InputStream inputStream = null;
                         try {
-                            String urlPath;
-                            if ("http".equals(m3U8Ts.getFile().substring(0, 4))) {
-                                urlPath = m3U8Ts.getFile();
-                            } else {
-                                urlPath = basePath + m3U8Ts.getFile();
-                            }
+                            String urlPath = MUtils.getRealDownloadPath(basePath, m3U8Ts.getFile());
                             URL url = new URL(urlPath);
 
                             HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/m3u8manger_lib/src/main/java/com/hdl/m3u8/M3U8Manger.java
+++ b/m3u8manger_lib/src/main/java/com/hdl/m3u8/M3U8Manger.java
@@ -315,7 +315,8 @@ public class M3U8Manger {
                                 long size = 0;
                                 try {
                                     writer = new FileOutputStream(new File(dir, ts.getFileName()));
-                                    size = IOUtils.copyLarge(new URL(m3u8.getBasepath() + ts.getFileName()).openStream(), writer);
+                                    String downloadPath = MUtils.getRealDownloadPath(m3u8.getBasepath(), ts.getFile());
+                                    size = IOUtils.copyLarge(new URL(downloadPath).openStream(), writer);
                                 } catch (InterruptedIOException exception) {
                                     isRunning = false;
                                     currDownloadTsCount = 0;

--- a/m3u8manger_lib/src/main/java/com/hdl/m3u8/utils/MUtils.java
+++ b/m3u8manger_lib/src/main/java/com/hdl/m3u8/utils/MUtils.java
@@ -19,6 +19,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * M3u8工具类
  * Created by HDL on 2017/7/24.
@@ -55,7 +58,8 @@ public class MUtils {
                     continue;
                 }
                 if (line.endsWith("m3u8")) {
-                    return parseIndex(basepath + line);
+                    String downloadPath = getRealDownloadPath(basepath, line);
+                    return parseIndex(downloadPath);
                 }
                 ret.addTs(new M3U8Ts(line, seconds));
                 seconds = 0;
@@ -156,6 +160,32 @@ public class MUtils {
                 dir.delete();// 删除文件夹
             }
         }
+    }
+
+
+    /**
+     * 获取真正的ts下载地址
+     *
+     * @param basePath
+     * @param filePath
+     */
+    public static String getRealDownloadPath (String basePath, String filePath) {
+
+        if (filePath.startsWith("http")) {//如果是完成的http路径，则不需要变更
+            return filePath;
+
+        } else if (filePath.startsWith("/")) {//根开头
+            //截取basePath的host
+            String host = "";
+            Pattern patHost =  Pattern.compile("(http://|https://)?([^/]*)");
+            Matcher matHost = patHost.matcher(basePath); 
+            if(matHost.find()){
+                host = matHost.group(0); 
+            }
+            return host + filePath;
+        }
+
+        return basePath + filePath;
     }
 
     /**


### PR DESCRIPTION
ts的路径需要适配多个情况，例如带"http"的、还有前面带根"/"的。
当前版本只是适配了不带根"/"的情况，获取的Basepath只是m3u8文件url的当前目录，所以在拼接ts下载文件路径的时候会出现404的情况。